### PR TITLE
Makefile: Allow bin/ to be created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ $(BIN)/$(EXE): $(OBJECT)
 	$(CC) $^ -o $@
 
 $(BIN)/%.o: $(SRC)/%.c
+	@mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(DIR) -c $< -o $@
 
 # Help Option


### PR DESCRIPTION
Previously, the compilation was getting terminated
if the bin/ directory was not manually created.
A mkdir -p command is added in the comilation phase
which should take care of it if it is not already
present

fixes: #27

Signed-off-by: Rudra Nil Basu <rudra.nil.basu.1996@gmail.com>
